### PR TITLE
Added Classic Template without Extra summary

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -202,7 +202,7 @@ h4 {
     font-size: 14pt !important;
 }
 
-.headding {
+.heading {
     font-size: 12pt;
     margin-bottom: 5px;
 }

--- a/src/components/pages/Preview.vue
+++ b/src/components/pages/Preview.vue
@@ -22,6 +22,8 @@
 							<option value="8">🟦 Modern Sidebar (Left)</option>
 							<option value="9">🌗 Clean Split (Right)</option>
 							<option value="10">🎨 Modern Portfolio (Zain Style)</option>
+							<option value="11">📄 Classic Professional (Without Extra Summary)</option>
+
 						</select>
 					</div>
 
@@ -95,6 +97,7 @@
 					<Template8 v-else-if="template == '8'" :data="maindata" />
 					<Template9 v-else-if="template == '9'" :data="maindata" />
 					<Template10 v-else-if="template == '10'" :data="maindata" />
+					<Template11 v-else-if="template == '11'" :data="maindata" />
 				</page>
 			</div>
 		</div>
@@ -134,6 +137,7 @@ import Template7 from "../templates/Template7.vue"
 import Template8 from "../templates/TemplateSidebarLeft.vue"
 import Template9 from "../templates/TemplateSplitRight.vue"
 import Template10 from "../templates/TemplateModernPortfolio.vue"
+import Template11 from "../templates/Simple_Template.vue"
 
 export default {
 	name: "Preview",
@@ -148,7 +152,8 @@ export default {
 		Template7,
 		Template8,
 		Template9,
-		Template10
+		Template10,
+		Template11
 	},
 	data() {
 		return {

--- a/src/components/previews/Education.vue
+++ b/src/components/previews/Education.vue
@@ -2,7 +2,7 @@
 	<table v-if="eds.length">
 		<tbody>
 			<tr>
-				<td>
+				<td class="section_heading">
 					<h4 role="heading" style="margin-bottom:5px">EDUCATION</h4>
 				</td>
 			</tr>
@@ -12,7 +12,7 @@
 						{{ date(ed.start, ed.end) }}
 					</i>
 					<br v-if="ed.end || ed.start" />
-					<strong  class="degree headding" v-if="ed.major || ed.degree">
+					<strong  class="degree heading" v-if="ed.major || ed.degree">
 						<span v-if="ed.degree">{{ ed.degree }}</span>
 						<br v-if="ed.degree.length + ed.major.length > 50" />
 						<span v-if="ed.major">({{ ed.major }})</span>

--- a/src/components/previews/Experience.vue
+++ b/src/components/previews/Experience.vue
@@ -2,7 +2,7 @@
 	<table style="width: 100%;">
 		<tbody>
 			<tr>
-				<td>
+				<td class="section_heading">
 					<h4 role="heading" style="margin-bottom:5px;font-size: 12pt;">EXPERIENCE</h4>
 				</td>
 			</tr>
@@ -12,7 +12,7 @@
 						{{ date(exp.start, exp.end) }}
 					</i>
 					<br>
-					<strong class="headding" v-if="exp.title.length" :style="{ fontWeight: 'bold' }">
+					<strong class="heading" v-if="exp.title.length" :style="{ fontWeight: 'bold' }">
 						{{ exp.title.toUpperCase() }}
 						<br />
 					</strong>

--- a/src/components/previews/Project.vue
+++ b/src/components/previews/Project.vue
@@ -2,7 +2,7 @@
 	<table style="width: 100%;">
 		<tbody>
 			<tr>
-				<td>
+				<td class="section_heading">
 					<h4 role="heading" style="margin-bottom:5px; font-size: 12pt;">PROJECTS</h4>
 				</td>
 			</tr>
@@ -12,7 +12,7 @@
 						{{ date(proj.start, proj.end) }}
 					</i>
 					<br />
-					<strong class="headding" v-if="proj.title" :style="{ fontWeight: 'bold' }">
+					<strong class="heading" v-if="proj.title" :style="{ fontWeight: 'bold' }">
 						{{ proj.title }}
 						<br />
 					</strong>

--- a/src/components/previews/profile/First_WithoutSummary.vue
+++ b/src/components/previews/profile/First_WithoutSummary.vue
@@ -1,0 +1,49 @@
+<template>
+	<table style="width: 100%;text-align: left;" >
+		<tr>
+			<td colspan="2">
+				<h1 style="margin-bottom:0">
+					{{ profile.name }}
+				</h1>
+			</td>
+		</tr>
+		<tr>
+			<td colspan="2">
+				<h5 v-if="profile.title">
+					{{ profile.title }}
+				</h5>
+			</td>
+		</tr>
+		<tr>
+			<td style="max-width: 50%;">
+				{{ profile.address }}
+			</td>
+			<td valign="top" class="text-end">
+				{{ profile.website }}
+			</td>
+		</tr>
+		<tr>
+			<td style="max-width: 50%;">
+				{{ profile.phone }}
+			</td>
+			<td valign="top" class="text-end">
+				{{ profile.github }}
+			</td>
+		</tr>
+		<tr>
+			<td style="max-width: 50%;">
+				{{ profile.email }}
+			</td>
+			<td valign="top" class="text-end">
+				{{ profile.linkedin }}
+			</td>
+		</tr>
+	</table>
+</template>
+
+<script>
+export default {
+	name: "PP",
+	props: ["profile"],
+}
+</script>

--- a/src/components/previews/profile/Second.vue
+++ b/src/components/previews/profile/Second.vue
@@ -42,7 +42,7 @@
 			<tr style="text-align: center">
 				<td colspan="2">
 					<div v-if="profile.summary">
-						<h3 class="headding">SUMMARY</h3>
+						<h3 class="heading">SUMMARY</h3>
 						{{ profile.summary }}
 					</div>
 					<hr />

--- a/src/components/previews/profile/Third.vue
+++ b/src/components/previews/profile/Third.vue
@@ -10,7 +10,7 @@
 		<i class="bi bi-linkedin"></i> {{ profile.linkedin.split("/")[profile.linkedin.split("/").length-1] }} <br>
 		<hr>
 		<div v-if="profile.summary">
-			<h4 class="headding">SUMMARY</h4>
+			<h4 class="heading">SUMMARY</h4>
 			{{ profile.summary }}
 		</div>
 		<hr>

--- a/src/components/templates/Simple_Template.vue
+++ b/src/components/templates/Simple_Template.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script>
-import PProf from "../previews/profile/First.vue"
+import PProf from "../previews/profile/First_WithoutSummary.vue"
 import PEXP from "../previews/Experience.vue"
 import PEDU from "../previews/Education.vue"
 import PSKILL1 from "../previews/Skills.vue"


### PR DESCRIPTION
Added classic template without extra summary
correct class spelling from headding to heading.

ignore this line for now `<td class="section_heading">`, relevant css will be added in next commits